### PR TITLE
Handle passing an account when posting sendupdate

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -2241,6 +2241,20 @@ class TXDB {
   }
 
   /**
+   * Test whether an account owns a coin.
+   * @param {Number} acct
+   * @param {Hash} hash
+   * @param {Index} number
+   * @returns {Promise} - Returns Boolean.
+   */
+
+  hasCoinByAccount(acct, hash, index) {
+    assert(typeof acct === 'number');
+
+    return this.bucket.has(layout.C.encode(acct, hash, index));
+  }
+
+  /**
    * Get hashes of all transactions in the database.
    * @param {Number} acct
    * @returns {Promise} - Returns {@link Hash}[].

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2329,9 +2329,14 @@ class Wallet extends EventEmitter {
    * @returns {MTX}
    */
 
-  async makeUpdate(name, resource) {
+  async makeUpdate(name, resource, acct) {
     assert(typeof name === 'string');
     assert(resource instanceof Resource);
+
+    if (acct) {
+      assert((acct >>> 0) === acct || typeof acct === 'string');
+      acct = await this.getAccountIndex(acct);
+    }
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
@@ -2350,6 +2355,9 @@ class Wallet extends EventEmitter {
 
     if (!coin)
       throw new Error(`Wallet does not own: "${name}".`);
+
+    if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
+      throw new Error(`Account does not own: "${name}".`);
 
     if (coin.covenant.isReveal() || coin.covenant.isClaim())
       return this._makeRegister(name, resource);
@@ -2403,7 +2411,8 @@ class Wallet extends EventEmitter {
    */
 
   async _createUpdate(name, resource, options) {
-    const mtx = await this.makeUpdate(name, resource);
+    const acct = options ? options.account : null;
+    const mtx = await this.makeUpdate(name, resource, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1742,8 +1742,13 @@ class Wallet extends EventEmitter {
    * @returns {MTX}
    */
 
-  async makeReveal(name) {
+  async makeReveal(name, acct) {
     assert(typeof name === 'string');
+
+    if (acct) {
+      assert((acct >>> 0) === acct || typeof acct === 'string');
+      acct = await this.getAccountIndex(acct);
+    }
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
@@ -1779,6 +1784,9 @@ class Wallet extends EventEmitter {
       const coin = await this.getCoin(hash, index);
 
       if (!coin)
+        continue;
+
+      if (acct && !await this.txdb.hasCoinByAccount(acct, hash, index))
         continue;
 
       // Is local?
@@ -1820,7 +1828,8 @@ class Wallet extends EventEmitter {
    */
 
   async _createReveal(name, options) {
-    const mtx = await this.makeReveal(name);
+    const acct = options ? options.account : null;
+    const mtx = await this.makeReveal(name, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }

--- a/test/double-reveal-test.js
+++ b/test/double-reveal-test.js
@@ -1,0 +1,103 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const Network = require('../lib/protocol/network');
+const FullNode = require('../lib/node/fullnode');
+const Address = require('../lib/primitives/address');
+const rules = require('../lib/covenants/rules');
+
+const network = Network.get('regtest');
+
+const node = new FullNode({
+  memory: true,
+  network: 'regtest',
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+const {wdb} = node.require('walletdb');
+const name = rules.grindName(10, 20, network);
+
+let wallet, alice, bob, aliceMiner, bobMiner;
+
+async function mineBlocks(n, addr) {
+  addr = addr ? addr : new Address().toString('regtest');
+  for (let i = 0; i < n; i++) {
+    const block = await node.miner.mineBlock(null, addr);
+    await node.chain.add(block);
+  }
+}
+
+describe('One wallet, two accounts, one name', function() {
+  before(async () => {
+    await node.open();
+
+    wallet = await wdb.create();
+
+    alice = await wallet.createAccount({name: 'alice'});
+    bob = await wallet.createAccount({name: 'bob'});
+
+    aliceMiner = await alice.receiveAddress();
+    bobMiner = await bob.receiveAddress();
+  });
+
+  after(async () => {
+    await node.close();
+  });
+
+  it('should fund both accounts', async () => {
+    await mineBlocks(10, aliceMiner);
+    await mineBlocks(10, bobMiner);
+
+    // Wallet rescan is an effective way to ensure that
+    // wallet and chain are synced before proceeding.
+    await wdb.rescan(0);
+
+    const aliceBal = await wallet.getBalance('alice');
+    const bobBal = await wallet.getBalance('bob');
+    assert(aliceBal.confirmed === 2000 * 10 * 1e6);
+    assert(bobBal.confirmed === 2000 * 10 * 1e6);
+  });
+
+  it('should open an auction and proceed to REVEAL phase', async () => {
+    await wallet.sendOpen(name, false, {account: 'alice'});
+    await mineBlocks(network.names.treeInterval + 2);
+    let ns = await node.chain.db.getNameStateByName(name);
+    assert(ns.isBidding(node.chain.height, network));
+
+    await wdb.rescan(0);
+
+    await wallet.sendBid(name, 100000, 200000, {account: 'alice'});
+    await wallet.sendBid(name, 50000, 200000, {account: 'bob'});
+    await mineBlocks(network.names.biddingPeriod);
+    ns = await node.chain.db.getNameStateByName(name);
+    assert(ns.isReveal(node.chain.height, network));
+
+    await wdb.rescan(0);
+
+    const walletBids = await wallet.getBidsByName(name);
+    assert.strictEqual(walletBids.length, 2);
+
+    for (const bid of walletBids)
+      assert(bid.own);
+  });
+
+  it('should send REVEAL from one account at a time', async () => {
+    const tx1 = await wallet.sendReveal(name, {account: 'alice'});
+    assert(tx1);
+
+    const tx2 = await wallet.sendReveal(name, {account: 'bob'});
+    assert(tx2);
+
+    // Reset for next test
+    await wallet.abandon(tx1.hash());
+    await wallet.abandon(tx2.hash());
+  });
+
+  it('should send REVEAL from all accounts', async () => {
+    const tx = await wallet.sendRevealAll();
+    assert(tx);
+  });
+});


### PR DESCRIPTION
### Context

Originally, issue #231 brought up a similar issue surrounding `sendReveal` and specifying accounts.  This work aims to extend https://github.com/handshake-org/hsd/pull/233

It raises an exception when passed an account that does not match the would-be coin's owner:
https://github.com/pinheadmz/hsd/pull/1/files#diff-10775d9a238b8247721a7dc0600d5a8aR2360 

### Todo
- [ ] Tests.